### PR TITLE
Add JP translation for ankle settings

### DIFF
--- a/src/static/languages/jp.json
+++ b/src/static/languages/jp.json
@@ -92,10 +92,10 @@
         },
         "ankle": {
             "title": "足首動き検知機能",
-            "tooltip": "トラッカーの足首検知機能（距離センサー）を有効にして、SlimeVRで使用する仮想トラッカーを作成します。",
+            "tooltip": "足首トラッカーの足首動き検知機能（距離センサー）を有効にして、SlimeVRで使用する仮想の足トラッカーを作成します。",
             "ankle": "足首検知を有効にする",
-            "leftAnkle": "左足",
-            "rightAnkle": "右足",
+            "leftAnkle": "左足首",
+            "rightAnkle": "右足首",
             "placeholder": "デバイスIDを入力"
         }
     },

--- a/src/static/languages/jp.json
+++ b/src/static/languages/jp.json
@@ -89,6 +89,14 @@
             "accelerometer": "加速度",
             "gyroscope": "ジャイロ",
             "magnetometer": "地磁気"
+        },
+        "ankle": {
+            "title": "足首動き検知機能",
+            "tooltip": "トラッカーの足首検知機能（距離センサー）を有効にして、SlimeVRで使用する仮想トラッカーを作成します。",
+            "ankle": "足首検知を有効にする",
+            "leftAnkle": "左足",
+            "rightAnkle": "右足",
+            "placeholder": "デバイスIDを入力"
         }
     },
     "about": {


### PR DESCRIPTION
Updated Japanese translation.

In Japanese, the wording has been changed from "Feet trackers (w/ ankle data)" to "Enable ankle motion detection"
The phrase "ankle motion detection（足首動き検知）" should be familiar to HaritoraX users in Japan.

Please let me know if there are any problems.